### PR TITLE
Add support for ignoring containers with `docgraf.ignore` label.

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -23,3 +23,21 @@ For example, if you defined a setting ONLY in the Config file, then the Config f
 If you defined a setting in both the Config file AND the Environment variables, then the Environment variable setting will be used.
 
 If you defined a setting using all 3 methods (config file, env, and command line), then the setting provided via the command line will be used.
+
+
+## Ignoring Certain Containers
+
+DocGraf will ignore any containers that have the label `docgraf.ignore=true`.
+This may be useful for short-lived containers that run as part of cron jobs etc.
+This label can either be added using docker run:
+```bash
+docker run --label docgraf.ignore=true my_image
+```
+or via docker compose:
+```yaml
+services:
+    my_container:
+      image: my_image
+      labels:
+        docgraf.ignore: true 
+```

--- a/src/Common/Constants.cs
+++ b/src/Common/Constants.cs
@@ -8,5 +8,5 @@ public static class Constants
 
 	public const string ConsoleAppName = "docgraf_console";
 
-	public const string AppVersion = "1.1.0";
+	public const string AppVersion = "1.2.0-rc";
 }

--- a/src/Core/Docker/Constants.cs
+++ b/src/Core/Docker/Constants.cs
@@ -16,4 +16,6 @@ internal class Constants
 	public const string SecretEventTypeValue = "secret";
 	public const string ConfigEventTypeValue = "config";
 	public const string NetworkEventTypeValue = "network";
+	
+	public const string IgnoreLabelKey = "docgraf.ignore";
 }

--- a/src/Core/Docker/DockerClient.cs
+++ b/src/Core/Docker/DockerClient.cs
@@ -112,7 +112,7 @@ public class DockerClient : IDockerClientWrapper
 							message.ID, message.Action, message.From, message.Actor, message.Scope, message.Status, message.Type, message.Time);
 
 			var action = CleanAction(message.Action);
-			var shouldRecord = ShouldRecordToGrafana(action);
+			var shouldRecord = ShouldRecordToGrafana(action, message.Actor.Attributes);
 			var messageType = MapToGrafanaEventType(message.Type);
 
 			message.Actor.Attributes.TryGetValue(Constants.ContainerNameKey, out var containerName);
@@ -157,12 +157,16 @@ public class DockerClient : IDockerClientWrapper
 		return messageType;
 	}
 
-	private bool ShouldRecordToGrafana(string action)
+	private bool ShouldRecordToGrafana(string action, IDictionary<string, string> actorAttributes)
 	{
 		using var tracing = Traces.Trace($"{nameof(DockerClient)}.{nameof(ShouldRecordToGrafana)}");
 
+		actorAttributes.TryGetValue(Constants.IgnoreLabelKey, out var ignoreLabel);
+		bool.TryParse(ignoreLabel, out var ignore);
+		
 		var shouldRecord = false;
-		if (_containerActionsToRecord.Contains(action)
+		if (!ignore && (
+			_containerActionsToRecord.Contains(action)
 			|| _imageActionsToRecord.Contains(action)
 			|| _pluginActionsToRecord.Contains(action)
 			|| _volumeActionsToRecord.Contains(action)
@@ -170,7 +174,8 @@ public class DockerClient : IDockerClientWrapper
 			|| _serviceActionsToRecord.Contains(action)
 			|| _nodeActionsToRecord.Contains(action)
 			|| _secretActionsToRecord.Contains(action)
-			|| _configActionsToRecord.Contains(action))
+			|| _configActionsToRecord.Contains(action)
+		))
 			shouldRecord = true;
 
 		tracing?.AddTag("docgraf.shouldRecordEvent", shouldRecord);


### PR DESCRIPTION
When picking up docker events, the labels are checked for the presence of a `docgraf.ignore` label with a value of `true`. If found, the event will not be passed through to grafana.